### PR TITLE
Fix: 修复Railway端口配置

### DIFF
--- a/app.py
+++ b/app.py
@@ -579,4 +579,5 @@ if __name__ == "__main__":
     print(f"💾 记忆存储: {AppConfig.MEMORY_STORAGE_TYPE}")
     print("-" * 50)
     
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+    port = int(os.getenv("PORT", 8000))
+    uvicorn.run(app, host="0.0.0.0", port=port)


### PR DESCRIPTION
- 使用环境变量PORT而不是固定端口8000
- 确保Railway部署时能正确绑定端口